### PR TITLE
Corrigindo crash ao ler ICMS

### DIFF
--- a/lib/impostos.js
+++ b/lib/impostos.js
@@ -8,11 +8,11 @@
       ProdutoCOFINS = require('./produto.cofins');
 
   function Impostos(impostos) {
-    var icms = impostos.ICMS[0],
+    var icms = (impostos.ICMS ? impostos.ICMS[0] : null),
         pis = impostos.PIS[0],
         cofins = impostos.COFINS[0];
 
-    if (icms.ICMS60) {
+    if (icms && icms.ICMS60) {
       this.ICMS = new ProdutoICMS(icms.ICMS60[0]);
     };
 


### PR DESCRIPTION
Se a nota for de serviço (que não há ICMS) o impostos.js crasha.
